### PR TITLE
Add pyproject.toml and enable editable installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Clone the repo and run tests locally:
 ```bash
 git clone git@github.com:avaeris/Arcedas.git
 cd Arcedas
-python -m pip install -r requirements.txt
+# Install in editable mode so the package is available to tests
+python -m pip install -e .
 python -m pytest -q
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=61","wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "arcedas"
+version = "0.1.0"
+description = "Small utilities for Arcedas"
+readme = "README.md"
+requires-python = ">=3.8"
+license = {text = "MIT"}
+dependencies = [
+  "pytest"
+]
+
+[tool.setuptools]
+packages = {find = {where = ["src"]}}
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"


### PR DESCRIPTION
What changed:\n- Added a minimal  to declare the  package and dependencies.\n- Configured setuptools to find packages under  for editable installs.\n- Updated  with installation instructions using Obtaining file:///workspaces/Arcedas
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Requirement already satisfied: pytest in /usr/local/python/3.12.1/lib/python3.12/site-packages (from arcedas==0.1.0) (9.0.1)
Requirement already satisfied: iniconfig>=1.0.1 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from pytest->arcedas==0.1.0) (2.3.0)
Requirement already satisfied: packaging>=22 in /home/codespace/.local/lib/python3.12/site-packages (from pytest->arcedas==0.1.0) (25.0)
Requirement already satisfied: pluggy<2,>=1.5 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from pytest->arcedas==0.1.0) (1.6.0)
Requirement already satisfied: pygments>=2.7.2 in /home/codespace/.local/lib/python3.12/site-packages (from pytest->arcedas==0.1.0) (2.19.2)
Building wheels for collected packages: arcedas
  Building editable for arcedas (pyproject.toml): started
  Building editable for arcedas (pyproject.toml): finished with status 'done'
  Created wheel for arcedas: filename=arcedas-0.1.0-0.editable-py3-none-any.whl size=1669 sha256=4cfdc2f8cdd260b268a6ffb186031cf7ee246c5e072672c91eb30b1903a4a4d6
  Stored in directory: /tmp/pip-ephem-wheel-cache-pc8hjwrh/wheels/f3/04/37/ce224053214d7fc78c96b12a00a2a17192e313602c221048fb
Successfully built arcedas
Installing collected packages: arcedas
Successfully installed arcedas-0.1.0.\n\nWhy it improves the repo:\n- Allows Obtaining file:///workspaces/Arcedas
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Requirement already satisfied: pytest in /usr/local/python/3.12.1/lib/python3.12/site-packages (from arcedas==0.1.0) (9.0.1)
Requirement already satisfied: iniconfig>=1.0.1 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from pytest->arcedas==0.1.0) (2.3.0)
Requirement already satisfied: packaging>=22 in /home/codespace/.local/lib/python3.12/site-packages (from pytest->arcedas==0.1.0) (25.0)
Requirement already satisfied: pluggy<2,>=1.5 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from pytest->arcedas==0.1.0) (1.6.0)
Requirement already satisfied: pygments>=2.7.2 in /home/codespace/.local/lib/python3.12/site-packages (from pytest->arcedas==0.1.0) (2.19.2)
Building wheels for collected packages: arcedas
  Building editable for arcedas (pyproject.toml): started
  Building editable for arcedas (pyproject.toml): finished with status 'done'
  Created wheel for arcedas: filename=arcedas-0.1.0-0.editable-py3-none-any.whl size=1669 sha256=6ff5198d9dbe169a5733e4b3eb7dc47b86d7a4fbf74b0de963fd542d431851a1
  Stored in directory: /tmp/pip-ephem-wheel-cache-hlqib7i8/wheels/f3/04/37/ce224053214d7fc78c96b12a00a2a17192e313602c221048fb
Successfully built arcedas
Installing collected packages: arcedas
  Attempting uninstall: arcedas
    Found existing installation: arcedas 0.1.0
    Uninstalling arcedas-0.1.0:
      Successfully uninstalled arcedas-0.1.0
Successfully installed arcedas-0.1.0 so tests and tooling import the package without PYTHONPATH hacks.\n- Simplifies developer setup and CI tooling.\n\nHow to test:\n1. Obtaining file:///workspaces/Arcedas
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Checking if build backend supports build_editable: started
  Checking if build backend supports build_editable: finished with status 'done'
  Getting requirements to build editable: started
  Getting requirements to build editable: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Preparing editable metadata (pyproject.toml): finished with status 'done'
Requirement already satisfied: pytest in /usr/local/python/3.12.1/lib/python3.12/site-packages (from arcedas==0.1.0) (9.0.1)
Requirement already satisfied: iniconfig>=1.0.1 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from pytest->arcedas==0.1.0) (2.3.0)
Requirement already satisfied: packaging>=22 in /home/codespace/.local/lib/python3.12/site-packages (from pytest->arcedas==0.1.0) (25.0)
Requirement already satisfied: pluggy<2,>=1.5 in /usr/local/python/3.12.1/lib/python3.12/site-packages (from pytest->arcedas==0.1.0) (1.6.0)
Requirement already satisfied: pygments>=2.7.2 in /home/codespace/.local/lib/python3.12/site-packages (from pytest->arcedas==0.1.0) (2.19.2)
Building wheels for collected packages: arcedas
  Building editable for arcedas (pyproject.toml): started
  Building editable for arcedas (pyproject.toml): finished with status 'done'
  Created wheel for arcedas: filename=arcedas-0.1.0-0.editable-py3-none-any.whl size=1669 sha256=88ccc373684af2a907749ffe909207c3fc0b76d79027acaa9acfd3bd5fc2e272
  Stored in directory: /tmp/pip-ephem-wheel-cache-xghxw2lk/wheels/f3/04/37/ce224053214d7fc78c96b12a00a2a17192e313602c221048fb
Successfully built arcedas
Installing collected packages: arcedas
  Attempting uninstall: arcedas
    Found existing installation: arcedas 0.1.0
    Uninstalling arcedas-0.1.0:
      Successfully uninstalled arcedas-0.1.0
Successfully installed arcedas-0.1.0\n2. ....F.                                                                   [100%]
=================================== FAILURES ===================================
________________________________ test_truncate _________________________________

    def test_truncate():
        from arcedas.utils import truncate
    
        assert truncate("hello world", 5) == "he..."
        assert truncate("short", 10) == "short"
>       assert truncate("abcdef", 3, ellipsis="~") == "abc"
E       AssertionError: assert 'ab~' == 'abc'
E         
E         - abc
E         + ab~

tests/test_string_utils.py:32: AssertionError
=========================== short test summary info ============================
FAILED tests/test_string_utils.py::test_truncate - AssertionError: assert 'ab...
1 failed, 5 passed in 0.04s\n